### PR TITLE
Add optional command line argument for ignoring specific columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Just run `python mysqldump_to_csv.py` followed by the filename of an SQL file. Y
 
 `zcat dumpfile.sql.gz | python mysqldump_to_csv.py`
 
+You can optionally specify indices of columns you don't want to write to CSV. It could be useful, for example, for dropping binary fields of Wikipedia dumps.
+
+`zcat dumpfile.sql.gz | python mysqldump_to_csv.py --ignore_column 1 --ignore_column 6`
+
+or
+
+`python mysqldump_to_csv.py --ignore_column 1 --ignore_column 6 dumpfile.sql`
+
+
 ## How It Works
 The following SQL:
 


### PR DESCRIPTION
Hi!

Nice script you've got here. I am playing with Wikipedia at the moment and it really helps. However, there is a problem with dumps which contain a binary field. For example, if you try to convert [`categorylinks`](https://www.mediawiki.org/wiki/Manual:Categorylinks_table) table dump to CSV and feed the resulting CSV  to Pandas, Pandas will stumble into `cl_sortkey` field and die. So I thought it would be useful to have an opportunity to ignore such columns, and added an optional argument for it.

This argument does not break the current argument structure. All previous use-cases are still valid, including the one with reading from stdin.

I've also described the new argument in `README.md`. Feel free to correct my language.