### PR TITLE
Make some minor tweaks to `mysqldump_to_csv.py`

### DIFF
--- a/mysqldump_to_csv.py
+++ b/mysqldump_to_csv.py
@@ -30,7 +30,7 @@ def values_sanity_check(values):
     Ensures that values from the INSERT statement meet basic checks.
     """
     assert values
-    assert values[0] == '('
+    assert values[0].startswith("(")
     # Assertions have not been raised
     return True
 
@@ -53,16 +53,16 @@ def parse_values(values, outfile):
     for reader_row in reader:
         for column in reader_row:
             # If our current string is empty...
-            if len(column) == 0 or column == 'NULL':
+            if not column or column == "NULL":
                 latest_row.append(chr(0))
                 continue
             # If our string starts with an open paren
-            if column[0] == "(":
+            if column.startswith("("):
                 # Assume that this column does not begin
                 # a new row.
                 new_row = False
                 # If we've been filling out a row
-                if len(latest_row) > 0:
+                if latest_row:
                     # Check if the previous entry ended in
                     # a close paren. If so, the row we've
                     # been filling out has been COMPLETED
@@ -80,7 +80,7 @@ def parse_values(values, outfile):
                     latest_row = []
                 # If we're beginning a new row, eliminate the
                 # opening parentheses.
-                if len(latest_row) == 0:
+                if not latest_row:
                     column = column[1:]
             # Add our column to the row we're working on.
             latest_row.append(column)
@@ -88,7 +88,7 @@ def parse_values(values, outfile):
         # have the semicolon.
         # Make sure to remove the semicolon and
         # the close paren.
-        if latest_row[-1][-2:] == ");":
+        if latest_row[-1].endswith(");"):
             latest_row[-1] = latest_row[-1][:-2]
             writer.writerow(latest_row)
 

--- a/mysqldump_to_csv.py
+++ b/mysqldump_to_csv.py
@@ -7,23 +7,25 @@ import sys
 # This prevents prematurely closed pipes from raising
 # an exception in Python
 from signal import signal, SIGPIPE, SIG_DFL
+
 signal(SIGPIPE, SIG_DFL)
 
 # allow large content in the dump
 csv.field_size_limit(sys.maxsize)
 
+
 def is_insert(line):
     """
     Returns true if the line begins a SQL insert statement.
     """
-    return line.startswith('INSERT INTO') or False
+    return line.startswith("INSERT INTO") or False
 
 
 def get_values(line):
     """
     Returns the portion of an INSERT statement containing values
     """
-    return line.partition('` VALUES ')[2]
+    return line.partition("` VALUES ")[2]
 
 
 def values_sanity_check(values):
@@ -43,11 +45,13 @@ def parse_values(values, outfile):
     """
     latest_row = []
 
-    reader = csv.reader([values], delimiter=',',
-                        doublequote=False,
-                        escapechar='\\',
-                        quotechar="'",
-                        strict=True
+    reader = csv.reader(
+        [values],
+        delimiter=",",
+        doublequote=False,
+        escapechar="\\",
+        quotechar="'",
+        strict=True,
     )
 
     writer = csv.writer(outfile, quoting=csv.QUOTE_MINIMAL)
@@ -110,6 +114,7 @@ def main():
                     parse_values(values, sys.stdout)
     except KeyboardInterrupt:
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/mysqldump_to_csv.py
+++ b/mysqldump_to_csv.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import fileinput
+
 import csv
+import fileinput
 import sys
 
 # This prevents prematurely closed pipes from raising


### PR DESCRIPTION
* Use `.startswith(..)` in place of the unrolled versions of the
  equivalent functionality.
* Use `if foo:` and `if not foo:` instead of `if len(foo) != 0:`
  and `if len(foo) == 0:`. The former set of patterns is more
  performant and it protects against `foo` potentially not being
  an iterable object, or an object that doesn't implement
  `.__len__(..)`.
* Change the mode of the script to 0755 so it's executable out of
  the box.

Signed-of-by:	Enji Cooper <yaneurabeya@gmail.com>