### PR TITLE
Handling OverflowError

### DIFF
--- a/mysqldump_to_csv.py
+++ b/mysqldump_to_csv.py
@@ -9,7 +9,18 @@ from signal import signal, SIGPIPE, SIG_DFL
 signal(SIGPIPE, SIG_DFL)
 
 # allow large content in the dump
-csv.field_size_limit(sys.maxsize)
+maxInt = sys.maxsize
+while True:
+    """
+    decrease the maxInt value by factor 10 
+    as long as the OverflowError occurs.
+    """
+    try:
+        csv.field_size_limit(maxInt)
+        break
+    except OverflowError:
+        maxInt = int(maxInt/10)
+
 
 def is_insert(line):
     """


### PR DESCRIPTION
Implementing a try catch block which will set csv.field_size_limit(n) without OverflowError.
ref: https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072